### PR TITLE
latest changes from live coding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0, maximum-scale=1">
 
   <title>Connector.Land</title>
-  <meta name="description" content="Statistics for hosts, ledgers, and connectors on the Interledger">
+  <meta name="description" content="Statistics for hosts, ledgers, and routes on the Interledger">
   <link rel="icon" href="logo.png">
 
 
@@ -14,33 +14,15 @@
     Styles
   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/6.0.0/normalize.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/milligram/1.3.0/milligram.css">
+  <link rel="stylesheet" href="vendor/normalize.css">
+  <link rel="stylesheet" href="vendor/milligram.css">
   <link rel="stylesheet" href="style.css">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+  <script src="vendor/webfont.js"></script>
   <script>WebFont.load({ google: { families: ['Montserrat', 'Lato', 'Source Sans Pro'] } })</script>
 
 </head>
 <body>
-
-
-
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  Message for legacy browsers (IE <= 10)
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-<script>
-  if (/MSIE (6|7|8|9|10)\b/i.test(navigator.userAgent))
-    document.write('\
-      <div class="ui-legacy">\
-        <p>You are using an outdated browser.\
-        <br>Please <a href="https://www.google.com/chrome/browser/" target="_blank">upgrade</a> to improve your experience.</p>\
-        <p class="small" onclick="this.parentNode.style.display=\'none\'">I get it, <a>take me to the site</a>.</p>\
-      </div>')
-</script>
-
-
 
 
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -55,7 +37,7 @@
 
     <a href="./"><img alt="Interledger" class="logo" src="logo.png"></a>
 
-    <h1>Statistics for <a href="#/hosts">hosts</a>, <a href="#/ledgers">ledgers</a>, and <a href="#/connectors">connectors</a> on the <a href="https://interledger.org/" class="em">Interledger</a></h1>
+    <h1>Statistics for <a href="#/hosts">hosts</a>, <a href="#/ledgers">ledgers</a>, and <a href="#/routes">routes</a> on the <a href="https://interledger.org/" class="em">Interledger</a></h1>
 
     <a class="toggle">What is this?</a>
 
@@ -72,7 +54,7 @@
 
       <h3>What is this?</span></h3>
 
-      <p>This website lists hosts, ledgers, and connectors, that together make up the <a href="https://interledger.org/">Interledger</a>.</p>
+      <p>This website lists hosts, ledgers, and routes, that together make up the <a href="https://interledger.org/">Interledger</a>.</p>
 
       <p>Connectors connect two or more ledgers, similar to how Internet Switches link two or more computers.</p>
 
@@ -125,7 +107,7 @@
 <nav>
   <a href="#/hosts">Hosts</a>
   <a href="#/ledgers">Ledgers</a>
-  <a href="#/connectors">Connectors</a>
+  <a href="#/routes">Routes</a>
 </nav>
 
 
@@ -137,10 +119,10 @@
   Scripts
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-<script src="//code.jquery.com/jquery-3.2.1.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
-<script src="//cdn.rawgit.com/Teun/thenBy.js/248eb629/thenBy.min.js"></script>
+<script src="vendor/jquery-3.2.1.min.js"></script>
+<script src="vendor/sortable.js"></script>
+<script src="vendor/jquery.scrollTo.min.js"></script>
+<script src="vendor/thenBy.min.js"></script>
 <script src="script.js"></script>
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -422,7 +422,7 @@ td.col-address {
   text-align: right;
 }
 
-table.connectors tr > :nth-child(n+3) {
+table.routes tr > :nth-child(n+3) {
   text-align: left;
 }
 
@@ -431,17 +431,17 @@ table.connectors tr > :nth-child(n+3) {
   table.hosts .col-version,
   table.ledgers .col-balance,
   table.ledgers .col-delay,
-  table.connectors .col-delay + * {
+  table.routes .col-delay + * {
     padding-left: 130px;
   }
 }
 
-table.connectors th:nth-child(n+3) div {
+table.routes th:nth-child(n+3) div {
   padding-top: 5em;
   width: 2em;
 }
 
-table.connectors th:nth-child(n+3) div span {
+table.routes th:nth-child(n+3) div span {
   display: block;
   width: 9em;
   white-space: nowrap;

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,23 @@
 const Koa = require('koa')
 const koaStatic = require('koa-static')
 const IlpNode = require('ilp-node')
+const redis = require("redis")
 
-const statsFile = process.env.STATS_FILE
-const credsFile = process.env.CREDS_FILE
-const publicFolder = process.env.PUBLIC_FOLDER
-const hostname = process.env.HOSTNAME
-const port = process.env.PORT
-const probeInterval = process.env.PROBE_INTERVAL
+const publicFolder = process.env.PUBLIC_FOLDER || './public'
+const hostname = process.env.HOSTNAME || 'connector.land'
+const port = process.env.PORT || 6001 // avoid port 6000 because of https://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+const probeInterval = process.env.PROBE_INTERVAL || 10000
 
-const ilpNode = new IlpNode(statsFile, credsFile, hostname)
+const redisClient = redis.createClient({ url: process.env.REDIS_URL })
+redisClient.on('error', function (err) {
+  console.log('Error ' + err)
+})
+
+const ilpNode = new IlpNode(redisClient, hostname)
 
 const app = new Koa()
 app.use(async function(ctx, next) {
-  console.log(ctx.path)
+  // console.log(ctx.path)
   switch(ctx.path) {
   case '/.well-known/webfinger': ctx.body = await ilpNode.handleWebFinger(ctx.query.resource, '/spsp')
     break
@@ -23,13 +27,19 @@ app.use(async function(ctx, next) {
       ctx.req.on('data', chunk => str += chunk)
       ctx.req.on('end', resolve)
     })
+    // console.log('calling ilpNode.handleRpc')
     ctx.body = await ilpNode.handleRpc(ctx.query, JSON.parse(str))
+    // console.log('returned from ilpNode.handleRpc')
     break
-  case '/spsp': ctx.body = await ilpNode.handleSpsp()
+  case '/test':
+    console.log('test hit!', ctx.query)
+    ctx.body = await ilpNode.handleTest(ctx.query)
     break
   case '/stats':
     await ilpNode.ensureReady()
+    await ilpNode.collectLedgerStats(10000)
     if (typeof ctx.query.test === 'string') {
+      // console.log('testing!', ctx.query.test)
       await ilpNode.testHost(ctx.query.test)
     }
     ctx.body = ilpNode.stats
@@ -38,11 +48,14 @@ app.use(async function(ctx, next) {
     return next()
   }
   ctx.type = 'json'
-  console.log('rendered', ctx.path, ctx.query, ctx.body)
+  // console.log('rendered', ctx.path, ctx.query, ctx.body)
 })
 app.use(koaStatic(publicFolder))
 app.listen(port)
-
+console.log('listening on ', port)
 setInterval(() => {
   ilpNode.testAll()
 }, probeInterval)
+console.log('interval set!', probeInterval)
+  ilpNode.testAll()
+console.log('first test done!')


### PR DESCRIPTION
* Fixes #18
* Renames the Connectors tab to Routes
* Reincludes Internet Explorer users
* Supports "core nodes" that keep their rpc end-point secret (i.e. will display your server's title, not its hostname)
* Displays whether a ledger is part of the open interledger or of the testnet (will change again in #21)
* Update from ilp-kit 2 to ilp-kit 3 recommended version
* Use redis instead of test files for data storage
* Remove /spsp endpoint (I used to have tests for that, but focussing on lower-level protocols for now)